### PR TITLE
fix link in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ __This list is built to provide convenience for those who aim to immigrate to ot
 
 ## Contents
 
-- [Skilled Migrant Visa](skilled-migrant-visa)
+- [Skilled Migrant Visa](#skilled-migrant-visa)
 
-- [Post Study Visa](post-study-visa)
+- [Post Study Visa](#post-study-visa)
 
-- [Entrepreneur Visa](entrepreneur-visa)
+- [Entrepreneur Visa](#entrepreneur-visa)
 
 ## Skilled Migrant Visa
 


### PR DESCRIPTION
the current links in table of contents don't work and will redirect to 404 pages, solve the problem by adding hash sign ahead of each header name.